### PR TITLE
Add platformsh_relationship variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ GitHub Action to take a database dump from a platform.sh site and copy the dump 
   with:
     platformsh_project: 'XXXX-project-id'  # required.
     platformsh_environment: 'main'  # required.
-    platformsh_relationship: 'database'  # required if the project has multiple databases.
+    platformsh_relationship: 'database'  # optional. specify if the project has multiple databases.
     aws_s3_bucket: 'bucket-name'  # required.
     db_dump_filename_base: 'sitename-db-dump'
   env:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ GitHub Action to take a database dump from a platform.sh site and copy the dump 
   with:
     platformsh_project: 'XXXX-project-id'  # required.
     platformsh_environment: 'main'  # required.
+    platformsh_relationship: 'database'  # required if the project has multiple databases.
     aws_s3_bucket: 'bucket-name'  # required.
     db_dump_filename_base: 'sitename-db-dump'
   env:

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
   platformsh_environment:
     description: 'Platform.sh environment name.'
     required: true
+  platformsh_relationship:
+    description: 'Platform.sh relationship for multiple db projects.'
+    required: false
   aws_s3_bucket:
     description: 'AWS S3 bucket name.'
     required: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,15 +8,14 @@ sed -i 's/#   StrictHostKeyChecking ask.*/StrictHostKeyChecking accept-new/' /et
 FILENAME="${INPUT_DB_DUMP_FILENAME_BASE}-$(date +%F-%T)"
 
 # Check if the optional relationship value exists.
+RELATIONSHIP=""
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ]
 then
   echo "No relationship variable provided so no relationship parameter added to platform db:dump."
 else
-  # Manually add to args variable which can then hold many parameters.
-  # Subsequent parameters can be added in the same way, increasing the index.
-  args[0]="--relationship $INPUT_PLATFORMSH_RELATIONSHIP"
+  RELATIONSHIP="--relationship $INPUT_PLATFORMSH_RELATIONSHIP"
 fi
 
-platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" "${args[@]}" --gzip -f "$FILENAME".sql.gz
+platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" "$RELATIONSHIP" --gzip -f "$FILENAME".sql.gz
 
 aws s3 cp "$FILENAME".sql.gz s3://"$INPUT_AWS_S3_BUCKET"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,14 +7,13 @@ platform --version
 sed -i 's/#   StrictHostKeyChecking ask.*/StrictHostKeyChecking accept-new/' /etc/ssh/ssh_config
 FILENAME="${INPUT_DB_DUMP_FILENAME_BASE}-$(date +%F-%T)"
 
-# Use an array for extra arguments. Easy to add more in the future.
-args=()
 # Check if the optional relationship value exists.
-if [ -z ${INPUT_PLATFORMSH_RELATIONSHIP} ]
+if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ]
 then
   echo "No relationship variable provided so no relationship parameter added to platform db:dump."
 else
-  # Manually add to index zero for POSIX, which rejected += syntax.
+  # Manually add to args variable which can then hold many parameters.
+  # Subsequent parameters can be added in the same way, increasing the index.
   args[0]="--relationship $INPUT_PLATFORMSH_RELATIONSHIP"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,8 @@ if [ -z ${INPUT_PLATFORMSH_RELATIONSHIP} ]
 then
   echo "No relationship variable provided so no relationship parameter added to platform db:dump."
 else
-  args+=( "--relationship $INPUT_PLATFORMSH_RELATIONSHIP" )
+  # Manually add to index zero for POSIX, which rejected += syntax.
+  args[0]="--relationship $INPUT_PLATFORMSH_RELATIONSHIP"
 fi
 
 platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" "${args[@]}" --gzip -f "$FILENAME".sql.gz

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,16 @@ platform --version
 sed -i 's/#   StrictHostKeyChecking ask.*/StrictHostKeyChecking accept-new/' /etc/ssh/ssh_config
 FILENAME="${INPUT_DB_DUMP_FILENAME_BASE}-$(date +%F-%T)"
 
-platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --gzip -f "$FILENAME".sql.gz
+# Use an array for extra arguments. Easy to add more in the future.
+args=()
+# Check if the optional relationship value exists.
+if [ -z ${INPUT_PLATFORMSH_RELATIONSHIP} ]
+then
+  echo "No relationship variable provided so no relationship parameter added to platform db:dump."
+else
+  args+=( "--relationship $INPUT_PLATFORMSH_RELATIONSHIP" )
+fi
+
+platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" "${args[@]}" --gzip -f "$FILENAME".sql.gz
 
 aws s3 cp "$FILENAME".sql.gz s3://"$INPUT_AWS_S3_BUCKET"


### PR DESCRIPTION
## Description
@markdorison This PR is an attempt to update this action to support an optional `platformsh_relationship` argument that can (optionally) be passed in.

## Motivation / Context
Some platform.sh projects will have multiple databases that need to be backed up. (e.g. multisite projects)

## Testing Instructions / How This Has Been Tested
I tested this locally by outputting the command when a variable was present and when it was not. When the variable is present, then something akin to `--relationship database` (`database` being the actual variable value) will be part of the `platform db:dump` command parameters.
