### PR TITLE
Put platform db:dump command into conditional

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,14 +8,13 @@ sed -i 's/#   StrictHostKeyChecking ask.*/StrictHostKeyChecking accept-new/' /et
 FILENAME="${INPUT_DB_DUMP_FILENAME_BASE}-$(date +%F-%T)"
 
 # Check if the optional relationship value exists.
-RELATIONSHIP=""
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ]
 then
-  echo "No relationship variable provided so no relationship parameter added to platform db:dump."
+  # Run command without --relationship parameter.
+  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --gzip -f "$FILENAME".sql.gz
 else
-  RELATIONSHIP="--relationship $INPUT_PLATFORMSH_RELATIONSHIP"
+  # Run command with --relationship parameter.
+  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" --gzip -f "$FILENAME".sql.gz
 fi
-
-platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" "$RELATIONSHIP" --gzip -f "$FILENAME".sql.gz
 
 aws s3 cp "$FILENAME".sql.gz s3://"$INPUT_AWS_S3_BUCKET"


### PR DESCRIPTION
## Description
@markdorison This PR adjusts the conditional logic, putting the command inside the condition that checks for the presence of the `platformsh_relationship` variable. Doing it this way allows the `--relationship` parameter to be separate from the passed in variable value.

## Motivation / Context
Testing GH action that uses the `--relationship` parameter reported
```
  [RuntimeException]                                  
  The "--relationship expert" option does not exist. 
```

## Testing Instructions / How This Has Been Tested
Tested locally and successfully downloaded two separate DBs, based on the `platformsh_relationship` parameter being used.

```
Running command: ssh '-o' 'SendEnv TERM' '-o' 'CertificateFile /Users/mart/.platformsh/.session/sess-cli-default/ssh/id_ed25519-cert.pub' '-o' 'IdentityFile /Users/mart/.platformsh/.session/sess-cli-default/ssh/id_ed25519' '-o' 'IdentityFile /Users/mart/.ssh/id_rsa' 'tunagtrt2pdm4-master-7rqtwti--benzintuit@ssh.us-3.platform.sh' 'set -o pipefail; mysqldump --single-transaction --user='\''expert'\'' --password='\''1ee9cacb9a0e706243a3f333bdfe10f6'\'' --host='\''expert.internal'\'' --port=3306 '\''intuit_experts'\'' | gzip --stdout' > '/Users/mart/www/chromatic/benz-intuitbenefits.com/docroot/mytestexpertfile.sql.gz'
The dump completed successfully
  Time: 4.20s
  Size: 870 KiB
```
