### PR TITLE
GH-8 Add dump_only_these_tables input

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ GitHub Action to take a database dump from a platform.sh site and copy the dump 
     platformsh_relationship: 'database'  # optional. specify if the project has multiple databases.
     aws_s3_bucket: 'bucket-name'  # required.
     db_dump_filename_base: 'sitename-db-dump'
+    dump_only_these_tables: 'table_name another_table_name' # optional. limit the tables being dumped, separate the table names with spaces.
   env:
     PLATFORMSH_CLI_TOKEN: ${{ secrets.PLATFORMSH_CLI_TOKEN }}  # required.
     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}  # required.

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
     description: 'Filename for the database dump. A timestamp will be appended after it.'
     required: false
     default: 'db-dump'
+  dump_only_these_tables:
+    description: 'Limit the dumped tables to this list, separated by spaces.'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,14 +18,14 @@ do
   # Add table options into array.
   # DUMP_ONLY_THESE_TABLES+=("--table ${table}")
   # Concatenate table options into string.
-  DUMP_ONLY_THESE_TABLES+=" --table ${table}"
+  DUMP_ONLY_THESE_TABLES="${DUMP_ONLY_THESE_TABLES} --table ${table}"
 done
 echo "Testing manual string concatenation"
 TEST_VAR_ONE="testelog"
 TEST_VAR_TWO="testwatchdog"
 TEST_VARS=""
-TEST_VARS+="$TEST_VAR_ONE "
-TEST_VARS+="$TEST_VAR_TWO "
+TEST_VARS="${TEST_VARS} ${TEST_VAR_ONE}"
+TEST_VARS="${TEST_VARS} ${TEST_VAR_TWO}"
 echo "${TEST_VARS}"
 
 echo "About to echo the contents of DUMP_ONLY_THESE_TABLES"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,11 +21,11 @@ do
   DUMP_ONLY_THESE_TABLES+=" --table ${table}"
 done
 echo "Testing manual string concatenation"
-TEST_VAR_ONE=" --table testelog"
-TEST_VAR_TWO=" --table testwatchdog"
+TEST_VAR_ONE="testelog"
+TEST_VAR_TWO="testwatchdog"
 TEST_VARS=""
-TEST_VARS+="$TEST_VAR_ONE"
-TEST_VARS+="$TEST_VAR_TWO"
+TEST_VARS+="$TEST_VAR_ONE "
+TEST_VARS+="$TEST_VAR_TWO "
 echo "$TEST_VARS"
 
 echo "About to echo the contents of DUMP_ONLY_THESE_TABLES

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,13 +12,14 @@ echo "About to go into loop"
 # If we are not limiting the tables with INPUT_ONLY_INCLUDE_THESE_TABLES, then
 # this will pass harmlessly as an empty string in the platform db:dump command.
 # @todo Can malicious users run command injection attack with table name input?
-DUMP_ONLY_THESE_TABLES=""
+DUMP_ONLY_THESE_TABLES="--table "
 for table in ${INPUT_DUMP_ONLY_THESE_TABLES}
 do
   # Add table options into array.
   # DUMP_ONLY_THESE_TABLES+=("--table ${table}")
   # Concatenate table options into string.
-  DUMP_ONLY_THESE_TABLES="${DUMP_ONLY_THESE_TABLES} --table ${table}"
+  # DUMP_ONLY_THESE_TABLES="${DUMP_ONLY_THESE_TABLES} --table ${table}"
+  DUMP_ONLY_THESE_TABLES="${DUMP_ONLY_THESE_TABLES} ${table}"
 done
 echo "Testing manual string concatenation"
 TEST_VAR_ONE="testelog"
@@ -51,7 +52,7 @@ else
     # To get here we must have both --relationship and --app values available.
     # Run command with --relationship and --app parameters.
     # Also the optional DUMP_ONLY_THESE_TABLES argument limits to a subset of tables, separated by spaces.
-    platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" --app "$INPUT_PLATFORMSH_APP ${DUMP_ONLY_THESE_TABLES}" --gzip -f "$FILENAME".sql.gz
+    platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" --app "$INPUT_PLATFORMSH_APP" "${DUMP_ONLY_THESE_TABLES}" --gzip -f "$FILENAME".sql.gz
   fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,14 +7,23 @@ platform --version
 sed -i 's/#   StrictHostKeyChecking ask.*/StrictHostKeyChecking accept-new/' /etc/ssh/ssh_config
 FILENAME="${INPUT_DB_DUMP_FILENAME_BASE}-$(date +%F-%T)"
 
+# If we are not limiting the tables with INPUT_ONLY_INCLUDE_THESE_TABLES, then
+# this will pass harmlessly as an empty string in the platform db:dump command.
+# @todo Can malicious users run command injection attack with table name input?
+DUMP_ONLY_THESE_TABLES=""
+for table in ${INPUT_DUMP_ONLY_THESE_TABLES}
+do
+  DUMP_ONLY_THESE_TABLES+="--table $table "
+done
+
 # Check if the optional relationship value exists.
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ]
 then
   # Run command without --relationship parameter.
-  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --gzip -f "$FILENAME".sql.gz
+  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" ${DUMP_ONLY_THESE_TABLES} --gzip -f "$FILENAME".sql.gz
 else
   # Run command with --relationship parameter.
-  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" --gzip -f "$FILENAME".sql.gz
+  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" ${DUMP_ONLY_THESE_TABLES} --gzip -f "$FILENAME".sql.gz
 fi
 
 aws s3 cp "$FILENAME".sql.gz s3://"$INPUT_AWS_S3_BUCKET"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,27 +7,18 @@ platform --version
 sed -i 's/#   StrictHostKeyChecking ask.*/StrictHostKeyChecking accept-new/' /etc/ssh/ssh_config
 FILENAME="${INPUT_DB_DUMP_FILENAME_BASE}-$(date +%F-%T)"
 
-echo "About to go into loop"
-
 # If we are not limiting the tables with INPUT_ONLY_INCLUDE_THESE_TABLES, then
 # this will pass harmlessly as an empty string in the platform db:dump command.
 # @todo Can malicious users run command injection attack with table name input?
-DUMP_ONLY_THESE_TABLES="--table "
+DUMP_ONLY_THESE_TABLES=""
 for table in ${INPUT_DUMP_ONLY_THESE_TABLES}
 do
   # Add table options into array.
   # DUMP_ONLY_THESE_TABLES+=("--table ${table}")
   # Concatenate table options into string.
   # DUMP_ONLY_THESE_TABLES="${DUMP_ONLY_THESE_TABLES} --table ${table}"
-  DUMP_ONLY_THESE_TABLES="${DUMP_ONLY_THESE_TABLES} ${table}"
+  DUMP_ONLY_THESE_TABLES="${DUMP_ONLY_THESE_TABLES} --table=${table}"
 done
-echo "Testing manual string concatenation"
-TEST_VAR_ONE="testelog"
-TEST_VAR_TWO="testwatchdog"
-TEST_VARS=""
-TEST_VARS="${TEST_VARS} ${TEST_VAR_ONE}"
-TEST_VARS="${TEST_VARS} ${TEST_VAR_TWO}"
-echo "${TEST_VARS}"
 
 echo "About to echo the contents of DUMP_ONLY_THESE_TABLES"
 echo "${DUMP_ONLY_THESE_TABLES}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,7 @@ do
   echo "--table ${table}"
   # Add table options into array.
   # DUMP_ONLY_THESE_TABLES+=("--table ${table}")
+  # Concatenate table options into string.
   DUMP_ONLY_THESE_TABLES+="--table ${table} "
 done
 # Temporarily hard-code DUMP_ONLY_THESE_TABLES.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,19 +9,12 @@ FILENAME="${INPUT_DB_DUMP_FILENAME_BASE}-$(date +%F-%T)"
 
 # If we are not limiting the tables with INPUT_ONLY_INCLUDE_THESE_TABLES, then
 # this will pass harmlessly as an empty string in the platform db:dump command.
-# @todo Can malicious users run command injection attack with table name input?
 DUMP_ONLY_THESE_TABLES=""
 for table in ${INPUT_DUMP_ONLY_THESE_TABLES}
 do
-  # Add table options into array.
-  # DUMP_ONLY_THESE_TABLES+=("--table ${table}")
   # Concatenate table options into string.
-  # DUMP_ONLY_THESE_TABLES="${DUMP_ONLY_THESE_TABLES} --table ${table}"
   DUMP_ONLY_THESE_TABLES="${DUMP_ONLY_THESE_TABLES} --table=${table}"
 done
-
-echo "About to echo the contents of DUMP_ONLY_THESE_TABLES"
-echo "${DUMP_ONLY_THESE_TABLES}"
 
 # Check if neither optional relationship nor optional app value exists.
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ] && [ -z "${INPUT_PLATFORMSH_APP}" ]
@@ -42,8 +35,8 @@ else
   else
     # To get here we must have both --relationship and --app values available.
     # Run command with --relationship and --app parameters.
-    # Also the optional DUMP_ONLY_THESE_TABLES argument limits to a subset of tables, separated by spaces.
-    platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" --app "$INPUT_PLATFORMSH_APP" "${DUMP_ONLY_THESE_TABLES}" --gzip -f "$FILENAME".sql.gz
+    # Also the optional DUMP_ONLY_THESE_TABLES argument limits to a subset of tables, but it may be empty.
+    platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" --app "$INPUT_PLATFORMSH_APP" ${DUMP_ONLY_THESE_TABLES} --gzip -f "$FILENAME".sql.gz
   fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,9 +21,10 @@ do
   echo "--table ${table}"
   # Add table options into array.
   # DUMP_ONLY_THESE_TABLES+=("--table ${table}")
+  DUMP_ONLY_THESE_TABLES+="--table ${table} "
 done
 # Temporarily hard-code DUMP_ONLY_THESE_TABLES.
-DUMP_ONLY_THESE_TABLES="--table elog --table watchdog"
+# DUMP_ONLY_THESE_TABLES="--table elog --table watchdog"
 
 # Check if neither optional relationship nor optional app value exists.
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ] && [ -z "${INPUT_PLATFORMSH_APP}" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,17 +15,14 @@ echo "About to go into loop"
 DUMP_ONLY_THESE_TABLES=""
 for table in ${INPUT_DUMP_ONLY_THESE_TABLES}
 do
-  echo "Without parentheses..."
-  echo "--table $table"
-  echo "And now with parentheses..."
-  echo "--table ${table}"
   # Add table options into array.
   # DUMP_ONLY_THESE_TABLES+=("--table ${table}")
   # Concatenate table options into string.
   DUMP_ONLY_THESE_TABLES+="--table ${table} "
 done
-# Temporarily hard-code DUMP_ONLY_THESE_TABLES.
-# DUMP_ONLY_THESE_TABLES="--table elog --table watchdog"
+
+echo "About to echo the contents of DUMP_ONLY_THESE_TABLES
+echo $DUMP_ONLY_THESE_TABLES
 
 # Check if neither optional relationship nor optional app value exists.
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ] && [ -z "${INPUT_PLATFORMSH_APP}" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,10 +20,10 @@ done
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ]
 then
   # Run command without --relationship parameter.
-  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" "${DUMP_ONLY_THESE_TABLES}" --gzip -f "$FILENAME".sql.gz
+  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" ${DUMP_ONLY_THESE_TABLES} --gzip -f "$FILENAME".sql.gz
 else
   # Run command with --relationship parameter.
-  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" "${DUMP_ONLY_THESE_TABLES}" --gzip -f "$FILENAME".sql.gz
+  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" ${DUMP_ONLY_THESE_TABLES} --gzip -f "$FILENAME".sql.gz
 fi
 
 aws s3 cp "$FILENAME".sql.gz s3://"$INPUT_AWS_S3_BUCKET"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,10 +21,13 @@ done
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ]
 then
   # Run command without --relationship parameter.
-  `platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" ${DUMP_ONLY_THESE_TABLES[@]} --gzip -f "$FILENAME".sql.gz`
+  PLATFORM_COMMAND="platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" "${DUMP_ONLY_THESE_TABLES[@]}" --gzip -f "$FILENAME".sql.gz"
 else
   # Run command with --relationship parameter.
-  `platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" ${DUMP_ONLY_THESE_TABLES[@]} --gzip -f "$FILENAME".sql.gz`
+  PLATFORM_COMMAND="platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" "${DUMP_ONLY_THESE_TABLES[@]}" --gzip -f "$FILENAME".sql.gz"
 fi
+
+# Use command substitution.
+$($PLATFORM_COMMAND)
 
 aws s3 cp "$FILENAME".sql.gz s3://"$INPUT_AWS_S3_BUCKET"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ do
   echo "And now with parentheses..."
   echo "-- table ${table}"
   # Add table options into array.
-i#  DUMP_ONLY_THESE_TABLES+=("--table ${table}")
+  # DUMP_ONLY_THESE_TABLES+=("--table ${table}")
 done
 
 # Check if neither optional relationship nor optional app value exists.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -l
+#!/bin/sh -l
 
 php --version
 aws --version
@@ -13,17 +13,18 @@ FILENAME="${INPUT_DB_DUMP_FILENAME_BASE}-$(date +%F-%T)"
 DUMP_ONLY_THESE_TABLES=""
 for table in ${INPUT_DUMP_ONLY_THESE_TABLES}
 do
-  DUMP_ONLY_THESE_TABLES+="--table $table "
+  # Add table options into array.
+  DUMP_ONLY_THESE_TABLES+=("--table $table")
 done
 
 # Check if the optional relationship value exists.
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ]
 then
   # Run command without --relationship parameter.
-  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" ${DUMP_ONLY_THESE_TABLES} --gzip -f "$FILENAME".sql.gz
+  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" ${DUMP_ONLY_THESE_TABLES[@]} --gzip -f "$FILENAME".sql.gz
 else
   # Run command with --relationship parameter.
-  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" ${DUMP_ONLY_THESE_TABLES} --gzip -f "$FILENAME".sql.gz
+  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" ${DUMP_ONLY_THESE_TABLES[@]} --gzip -f "$FILENAME".sql.gz
 fi
 
 aws s3 cp "$FILENAME".sql.gz s3://"$INPUT_AWS_S3_BUCKET"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,8 +13,9 @@ FILENAME="${INPUT_DB_DUMP_FILENAME_BASE}-$(date +%F-%T)"
 DUMP_ONLY_THESE_TABLES=""
 for table in ${INPUT_DUMP_ONLY_THESE_TABLES}
 do
+  echo $table
   # Add table options into array.
-  DUMP_ONLY_THESE_TABLES+=("--table $table")
+  DUMP_ONLY_THESE_TABLES+=("--table ${table}")
 done
 
 # Check if neither optional relationship nor optional app value exists.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,7 +51,7 @@ else
     # To get here we must have both --relationship and --app values available.
     # Run command with --relationship and --app parameters.
     # Also the optional DUMP_ONLY_THESE_TABLES argument limits to a subset of tables, separated by spaces.
-    platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" --app "$INPUT_PLATFORMSH_APP" "${DUMP_ONLY_THESE_TABLES}" --gzip -f "$FILENAME".sql.gz
+    platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" --app "$INPUT_PLATFORMSH_APP ${DUMP_ONLY_THESE_TABLES}" --gzip -f "$FILENAME".sql.gz
   fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ php --version
 aws --version
 platform --version
 
-sed -i 's/#   StrictHostKeyChecking ask.*/StrictHostKeyChecking accept-new/' /etc/ssh/ssh_config
+sed -i 's/# StrictHostKeyChecking ask.*/StrictHostKeyChecking accept-new/' /etc/ssh/ssh_config
 FILENAME="${INPUT_DB_DUMP_FILENAME_BASE}-$(date +%F-%T)"
 
 # If we are not limiting the tables with INPUT_ONLY_INCLUDE_THESE_TABLES, then
@@ -21,13 +21,13 @@ done
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ]
 then
   # Run command without --relationship parameter.
-  PLATFORM_COMMAND="platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" "${DUMP_ONLY_THESE_TABLES[@]}" --gzip -f "$FILENAME".sql.gz"
+  PLATFORM_COMMAND="platform db:dump -v --yes --project $INPUT_PLATFORMSH_PROJECT --environment $INPUT_PLATFORMSH_ENVIRONMENT ${DUMP_ONLY_THESE_TABLES[*]} --gzip -f $FILENAME.sql.gz"
 else
   # Run command with --relationship parameter.
-  PLATFORM_COMMAND="platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" "${DUMP_ONLY_THESE_TABLES[@]}" --gzip -f "$FILENAME".sql.gz"
+  PLATFORM_COMMAND="platform db:dump -v --yes --project $INPUT_PLATFORMSH_PROJECT --environment $INPUT_PLATFORMSH_ENVIRONMENT --relationship $INPUT_PLATFORMSH_RELATIONSHIP ${DUMP_ONLY_THESE_TABLES[*]} --gzip -f $FILENAME.sql.gz"
 fi
 
-# Use command substitution.
-$($PLATFORM_COMMAND)
+# Run the string through eval to execute the platform db:dump command.
+eval "$PLATFORM_COMMAND"
 
 aws s3 cp "$FILENAME".sql.gz s3://"$INPUT_AWS_S3_BUCKET"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -l
+#!/bin/bash -l
 
 php --version
 aws --version
@@ -20,10 +20,10 @@ done
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ]
 then
   # Run command without --relationship parameter.
-  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" ${DUMP_ONLY_THESE_TABLES} --gzip -f "$FILENAME".sql.gz
+  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" "${DUMP_ONLY_THESE_TABLES}" --gzip -f "$FILENAME".sql.gz
 else
   # Run command with --relationship parameter.
-  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" ${DUMP_ONLY_THESE_TABLES} --gzip -f "$FILENAME".sql.gz
+  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" "${DUMP_ONLY_THESE_TABLES}" --gzip -f "$FILENAME".sql.gz
 fi
 
 aws s3 cp "$FILENAME".sql.gz s3://"$INPUT_AWS_S3_BUCKET"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,9 +15,12 @@ echo "About to go into loop"
 DUMP_ONLY_THESE_TABLES=""
 for table in ${INPUT_DUMP_ONLY_THESE_TABLES}
 do
-  echo $table
+  echo "Without parentheses..."
+  echo "-- table $table"
+  echo "And now with parentheses..."
+  echo "-- table ${table}"
   # Add table options into array.
-  DUMP_ONLY_THESE_TABLES+=("--table ${table}")
+i#  DUMP_ONLY_THESE_TABLES+=("--table ${table}")
 done
 
 # Check if neither optional relationship nor optional app value exists.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,10 +21,10 @@ done
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ]
 then
   # Run command without --relationship parameter.
-  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" ${DUMP_ONLY_THESE_TABLES[@]} --gzip -f "$FILENAME".sql.gz
+  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" `"${DUMP_ONLY_THESE_TABLES[@]}"` --gzip -f "$FILENAME".sql.gz
 else
   # Run command with --relationship parameter.
-  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" ${DUMP_ONLY_THESE_TABLES[@]} --gzip -f "$FILENAME".sql.gz
+  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" `"${DUMP_ONLY_THESE_TABLES[@]}"` --gzip -f "$FILENAME".sql.gz
 fi
 
 aws s3 cp "$FILENAME".sql.gz s3://"$INPUT_AWS_S3_BUCKET"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,6 +22,8 @@ do
   # Add table options into array.
   # DUMP_ONLY_THESE_TABLES+=("--table ${table}")
 done
+# Temporarily hard-code DUMP_ONLY_THESE_TABLES.
+DUMP_ONLY_THESE_TABLES = "--table elog --table watchdog"
 
 # Check if neither optional relationship nor optional app value exists.
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ] && [ -z "${INPUT_PLATFORMSH_APP}" ]
@@ -43,7 +45,7 @@ else
     # To get here we must have both --relationship and --app values available.
     # Run command with --relationship and --app parameters.
     # Also the optional DUMP_ONLY_THESE_TABLES argument limits to a subset of tables, separated by spaces.
-    platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" --app "$INPUT_PLATFORMSH_APP" ${DUMP_ONLY_THESE_TABLES[*]} --gzip -f "$FILENAME".sql.gz
+    platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" --app "$INPUT_PLATFORMSH_APP" ${DUMP_ONLY_THESE_TABLES} --gzip -f "$FILENAME".sql.gz
   fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,9 +16,9 @@ DUMP_ONLY_THESE_TABLES=""
 for table in ${INPUT_DUMP_ONLY_THESE_TABLES}
 do
   echo "Without parentheses..."
-  echo "-- table $table"
+  echo "--table $table"
   echo "And now with parentheses..."
-  echo "-- table ${table}"
+  echo "--table ${table}"
   # Add table options into array.
   # DUMP_ONLY_THESE_TABLES+=("--table ${table}")
 done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,10 +21,10 @@ done
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ]
 then
   # Run command without --relationship parameter.
-  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" `"${DUMP_ONLY_THESE_TABLES[@]}"` --gzip -f "$FILENAME".sql.gz
+  `platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" ${DUMP_ONLY_THESE_TABLES[@]} --gzip -f "$FILENAME".sql.gz`
 else
   # Run command with --relationship parameter.
-  platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" `"${DUMP_ONLY_THESE_TABLES[@]}"` --gzip -f "$FILENAME".sql.gz
+  `platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" ${DUMP_ONLY_THESE_TABLES[@]} --gzip -f "$FILENAME".sql.gz`
 fi
 
 aws s3 cp "$FILENAME".sql.gz s3://"$INPUT_AWS_S3_BUCKET"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,10 +26,10 @@ TEST_VAR_TWO="testwatchdog"
 TEST_VARS=""
 TEST_VARS+="$TEST_VAR_ONE "
 TEST_VARS+="$TEST_VAR_TWO "
-echo "$TEST_VARS"
+echo "${TEST_VARS}"
 
-echo "About to echo the contents of DUMP_ONLY_THESE_TABLES
-echo "$DUMP_ONLY_THESE_TABLES"
+echo "About to echo the contents of DUMP_ONLY_THESE_TABLES"
+echo "${DUMP_ONLY_THESE_TABLES}"
 
 # Check if neither optional relationship nor optional app value exists.
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ] && [ -z "${INPUT_PLATFORMSH_APP}" ]
@@ -51,7 +51,7 @@ else
     # To get here we must have both --relationship and --app values available.
     # Run command with --relationship and --app parameters.
     # Also the optional DUMP_ONLY_THESE_TABLES argument limits to a subset of tables, separated by spaces.
-    platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" --app "$INPUT_PLATFORMSH_APP" "$DUMP_ONLY_THESE_TABLES" --gzip -f "$FILENAME".sql.gz
+    platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" --app "$INPUT_PLATFORMSH_APP" "${DUMP_ONLY_THESE_TABLES}" --gzip -f "$FILENAME".sql.gz
   fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,8 @@ platform --version
 sed -i 's/#   StrictHostKeyChecking ask.*/StrictHostKeyChecking accept-new/' /etc/ssh/ssh_config
 FILENAME="${INPUT_DB_DUMP_FILENAME_BASE}-$(date +%F-%T)"
 
+echo "About to go into loop"
+
 # If we are not limiting the tables with INPUT_ONLY_INCLUDE_THESE_TABLES, then
 # this will pass harmlessly as an empty string in the platform db:dump command.
 # @todo Can malicious users run command injection attack with table name input?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ php --version
 aws --version
 platform --version
 
-sed -i 's/# StrictHostKeyChecking ask.*/StrictHostKeyChecking accept-new/' /etc/ssh/ssh_config
+sed -i 's/#   StrictHostKeyChecking ask.*/StrictHostKeyChecking accept-new/' /etc/ssh/ssh_config
 FILENAME="${INPUT_DB_DUMP_FILENAME_BASE}-$(date +%F-%T)"
 
 # If we are not limiting the tables with INPUT_ONLY_INCLUDE_THESE_TABLES, then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -l
+#!/bin/bash -l
 
 php --version
 aws --version

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,7 @@ do
   # DUMP_ONLY_THESE_TABLES+=("--table ${table}")
 done
 # Temporarily hard-code DUMP_ONLY_THESE_TABLES.
-DUMP_ONLY_THESE_TABLES = "--table elog --table watchdog"
+DUMP_ONLY_THESE_TABLES="--table elog --table watchdog"
 
 # Check if neither optional relationship nor optional app value exists.
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ] && [ -z "${INPUT_PLATFORMSH_APP}" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,11 +18,18 @@ do
   # Add table options into array.
   # DUMP_ONLY_THESE_TABLES+=("--table ${table}")
   # Concatenate table options into string.
-  DUMP_ONLY_THESE_TABLES+="--table ${table} "
+  DUMP_ONLY_THESE_TABLES+=" --table ${table}"
 done
+echo "Testing manual string concatenation"
+TEST_VAR_ONE=" --table testelog"
+TEST_VAR_TWO=" --table testwatchdog"
+TEST_VARS=""
+TEST_VARS+="$TEST_VAR_ONE"
+TEST_VARS+="$TEST_VAR_TWO"
+echo "$TEST_VARS"
 
 echo "About to echo the contents of DUMP_ONLY_THESE_TABLES
-echo $DUMP_ONLY_THESE_TABLES
+echo "$DUMP_ONLY_THESE_TABLES"
 
 # Check if neither optional relationship nor optional app value exists.
 if [ -z "${INPUT_PLATFORMSH_RELATIONSHIP}" ] && [ -z "${INPUT_PLATFORMSH_APP}" ]
@@ -44,7 +51,7 @@ else
     # To get here we must have both --relationship and --app values available.
     # Run command with --relationship and --app parameters.
     # Also the optional DUMP_ONLY_THESE_TABLES argument limits to a subset of tables, separated by spaces.
-    platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" --app "$INPUT_PLATFORMSH_APP" ${DUMP_ONLY_THESE_TABLES} --gzip -f "$FILENAME".sql.gz
+    platform db:dump -v --yes --project "$INPUT_PLATFORMSH_PROJECT" --environment "$INPUT_PLATFORMSH_ENVIRONMENT" --relationship "$INPUT_PLATFORMSH_RELATIONSHIP" --app "$INPUT_PLATFORMSH_APP" "$DUMP_ONLY_THESE_TABLES" --gzip -f "$FILENAME".sql.gz
   fi
 fi
 


### PR DESCRIPTION
## Description
@markdorison @adamzimmermann This PR adds an optional input, `dump_only_these_tables` that can take an arbitrary list of table names, separated by spaces.

The `entrypoint.sh` script loops through the list of table names and concatenates them into the `platform db:dump` command. If the input variable is missing or empty, the script does not mind and continues to run, dumping the entire DB, as expected.

## Testing
Tested locally.

## Related Ticket
- https://github.com/ChromaticHQ/benz-tickets/issues/2062