### PR TITLE
Convert platform CLI installation to new method

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@ updates:
     schedule:
       interval: daily
     reviewers:
-      - apotek
+      - ChromaticHQ/devops
     assignees:
-      - apotek
+      - ChromaticHQ/devops

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@ updates:
     schedule:
       interval: daily
     reviewers:
-      - markdorison
+      - apotek
     assignees:
-      - markdorison
+      - apotek

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,9 @@ FROM php:8-cli
 RUN apt-get update \
     && apt-get --quiet --yes --no-install-recommends install \
       keychain \
-      unzip \
-    && curl -L https://github.com/platformsh/platformsh-cli/releases/latest/download/platform.phar -o platform \
-    && chmod +x platform && mv platform /usr/local/bin/platform \
-    && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+      unzip
+RUN curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | bash
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \
     && ./aws/install
 


### PR DESCRIPTION
This updates our methodology for installing the platform CLI from the legacy version (4.x) to the current version (5.x) method as otherwise we are using a non-supported version of the platform command in this action.

I am also taking the opportunity to split out the RUN commands into several.

Resolves #32 
References ChromaticHQ/benz-tickets/issues/4190

## Testing Instructions / How This Has Been Tested
<!-- Describe how you tested your changes and/or how a reviewer can test your changes. -->

Change your action call from

```yaml
        uses: chromatichq/platformsh-db-dump-s3-sync-action@main
```

to

```yaml
        uses: chromatichq/platformsh-db-dump-s3-sync-action@update-platform-cli
```

And see if your action works. 